### PR TITLE
Make API base URL configurable via VITE_API_BASE

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-const BASE = 'http://localhost:8888';
+const BASE = import.meta.env.VITE_API_BASE ?? 'http://localhost:8888';
 
 export interface Entry {
   id: number;


### PR DESCRIPTION
## Summary

- Replace the hardcoded `http://localhost:8888` in `frontend/src/lib/api.ts` with `import.meta.env.VITE_API_BASE ?? 'http://localhost:8888'`
- No behavior change for local dev (`tlstart` still works as-is)
- Deployments behind a reverse proxy can now set `VITE_API_BASE` at build time

## Why

When the frontend is deployed behind a reverse proxy (e.g. Caddy/Nginx) on a non-localhost hostname, the API calls are made from the user's browser — so `localhost:8888` resolves to their own machine, not the backend. This makes the UI show "Could not load entries — is \`tlserve\` running?" even though the containers are healthy.

Falling back to the original default preserves the out-of-the-box developer experience while unblocking reverse-proxy deployments.

## Example deployment usage

Build the frontend with a relative `/api` base:

```bash
VITE_API_BASE=/api docker compose build frontend
```

Then proxy `/api/*` to the backend in Caddy:

```caddyfile
timelog.example.com {
    handle_path /api/* {
        reverse_proxy timelog-api-1:8888
    }
    reverse_proxy timelog-frontend-1:3000
}
```

## Test plan

- [x] `npm run build` in `frontend/` with no env var set — produces a build that calls `http://localhost:8888` (unchanged)
- [x] `VITE_API_BASE=/api npm run build` — produces a build that calls `/api/...`
- [x] Verified against a running deployment: frontend loads entries correctly when served behind Caddy with `/api/*` reverse-proxied to the backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)