### PR TITLE
Add CSV import feature and fix date column wrapping

### DIFF
--- a/frontend/src/routes/entries/+page.svelte
+++ b/frontend/src/routes/entries/+page.svelte
@@ -210,7 +210,7 @@
   }
 
   .bold  { font-weight: 600; color: #e2e8f0; }
-  .mono  { font-variant-numeric: tabular-nums; font-size: 0.85rem; color: #64748b; }
+  .mono  { font-variant-numeric: tabular-nums; font-size: 0.85rem; color: #64748b; white-space: nowrap; }
   .hours { font-variant-numeric: tabular-nums; font-weight: 600; color: #6366f1; }
 
   .badge {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "click>=8.0",
     "tabulate>=0.9",
     "fastapi>=0.115",
+    "python-multipart>=0.0.9",
     "uvicorn>=0.30",
 ]
 
@@ -21,5 +22,6 @@ tlshow   = "timelog.cli.show:show"
 tlsum    = "timelog.cli.summary:summary"
 tlupdate = "timelog.cli.update:update"
 tlexport = "timelog.cli.export:export"
+tlimport = "timelog.cli.import_:import_cmd"
 tlhelp   = "timelog.cli:help_cmd"
 tlserve  = "timelog.api:run"

--- a/timelog/api.py
+++ b/timelog/api.py
@@ -1,4 +1,6 @@
-from fastapi import FastAPI, HTTPException
+import tempfile
+import os
+from fastapi import FastAPI, HTTPException, UploadFile, File
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel, Field
 from timelog import service
@@ -109,6 +111,22 @@ def sum_per_category(month: str | None = None):
 @app.get("/sum/category/{name}")
 def sum_by_category(name: str):
     return {"hours": service.sum_by_category(name)}
+
+
+@app.post("/import", status_code=200)
+def import_csv(file: UploadFile = File(...)):
+    if not file.filename or not file.filename.endswith(".csv"):
+        raise HTTPException(status_code=400, detail="File must be a .csv")
+    with tempfile.NamedTemporaryFile(delete=False, suffix=".csv") as tmp:
+        tmp.write(file.file.read())
+        tmp_path = tmp.name
+    try:
+        count = service.import_from_csv(tmp_path)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+    finally:
+        os.unlink(tmp_path)
+    return {"imported": count}
 
 
 def run():

--- a/timelog/cli/__init__.py
+++ b/timelog/cli/__init__.py
@@ -41,4 +41,7 @@ COMMANDS
                 tlupdate YYYY-MM-DD  Sets the entry date explicitly
 
   tlexport    Export all entries to timelog-YYYY-MM-DD.csv
+
+  tlimport    Replace database with entries from a CSV file
+                tlimport <file.csv>
 """)

--- a/timelog/cli/import_.py
+++ b/timelog/cli/import_.py
@@ -1,0 +1,14 @@
+import click
+from timelog import service
+
+
+@click.command("tlimport")
+@click.argument("filepath", type=click.Path(exists=True, readable=True))
+def import_cmd(filepath: str) -> None:
+    """Replace the database with entries from a CSV file."""
+    click.echo(f"Importing from {filepath}...")
+    try:
+        count = service.import_from_csv(filepath)
+    except ValueError as e:
+        raise click.ClickException(str(e))
+    click.echo(f"Imported {count} entries.")

--- a/timelog/service.py
+++ b/timelog/service.py
@@ -202,6 +202,34 @@ def add_entry(
             )
 
 
+# ── Import ─────────────────────────────────────────────────────────────────
+
+def import_from_csv(filepath: str) -> int:
+    _ensure_init()
+    rows = []
+    with open(filepath, newline="") as f:
+        reader = csv.DictReader(f)
+        expected = {"id", "project", "category", "description", "hours", "date"}
+        if not expected.issubset(set(reader.fieldnames or [])):
+            raise ValueError(f"CSV must have columns: {', '.join(sorted(expected))}")
+        for row in reader:
+            rows.append((
+                int(row["id"]),
+                row["project"],
+                row["category"],
+                row["description"],
+                float(row["hours"]),
+                row["date"],
+            ))
+    with get_connection() as conn:
+        conn.execute("DELETE FROM entries")
+        conn.executemany(
+            "INSERT INTO entries (id, project, category, description, hours, date) VALUES (?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+    return len(rows)
+
+
 # ── Export ─────────────────────────────────────────────────────────────────
 
 def export_to_csv(filepath: str) -> None:


### PR DESCRIPTION
## Summary

- Adds `POST /import` API endpoint — accepts a `.csv` file upload and **replaces** the entire database with the imported entries (preserving original IDs)
- Adds `tlimport <file.csv>` CLI command as the terminal equivalent
- Adds `python-multipart` dependency required by FastAPI for file upload handling
- Fixes entries table date column wrapping with `white-space: nowrap`

## Test plan

- [x] Start the stack: `docker compose up -d`
- [x] **API import** — upload a valid CSV and verify row count matches:
  ```
  curl -X POST http://localhost:8888/import -F "file=@timelog-2026-04-19.csv"
  # expect: {"imported": N}
  curl http://localhost:8888/entries | jq length
  # expect: same N
  ```
- [x] **API import — bad file** — upload a non-CSV and confirm 400 error:
  ```
  curl -X POST http://localhost:8888/import -F "file=@README.md"
  # expect: 400 File must be a .csv
  ```
- [x] **API import — bad columns** — upload a CSV missing required columns and confirm 422 error
- [x] **CLI import** — run `tlimport timelog-2026-04-19.csv` inside the container or locally and confirm `Imported N entries.`
- [x] **CLI import — missing file** — run `tlimport nonexistent.csv` and confirm Click error (file not found)
- [x] **Idempotency** — import the same CSV twice; entry count should remain the same (old rows are cleared before insert)
- [x] **Date column** — open http://localhost:3000/entries and confirm dates render on a single line at all viewport widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)