### PR TITLE
Add GitHub-style activity heatmap to entries page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,110 @@ CREATE TABLE IF NOT EXISTS entries (
 )
 ```
 
+## Current Focus
+
+**Core improvements first.** The personal app is the priority — make it genuinely great before touching enterprise. All planned features below are core (MIT, single-user) and build toward a polished, fun, informative tool. Enterprise is a far-future vision, not active work.
+
+## Planned Features (Core — MIT)
+
+### 1. Entries Page — GitHub-style Heatmap
+52×7 SVG grid (last ~1 year), color intensity = hours logged per day. Pure SVG, no library. Filter-aware:
+- Intensity derived from `allEntries` filtered by current `project` + `category` (not date)
+- Clicking a cell sets `selectedDate` → table filters to that day + cell highlights
+- Changing project/category filter → heatmap intensities re-derive reactively
+- 5 intensity levels (0h, <2h, <4h, <6h, 6h+) using CSS vars for theme compat
+- Month labels above columns, tooltip on hover (date + hours)
+- No new API endpoint needed — all data already client-side in `allEntries`
+
+### 2. Charts Page (`/charts`) — Analytics Dashboard
+New route with multiple pure SVG/CSS charts, no charting library. Candidate charts:
+- **Donut — Hours by Project** (all time or date-ranged)
+- **Donut — Hours by Category**
+- **Stacked bar — Daily hours last 14 days**, color segments per project
+- **Weekly pace line** — daily hours vs 8h goal line, last 4 weeks (sparkline style)
+- **Project × Category heatmap** — grid: rows=projects, cols=categories, cell=hours; shows where time actually goes
+- Date range picker to scope all charts simultaneously
+- Charts use same CSS vars as themes so they look native
+
+### 3. Live Timer
+Start/stop timer → auto-calculates hours on stop, pre-fills log form. Biggest UX gap vs Toggl. State persisted to `localStorage` so refresh doesn't lose it.
+
+### 4. Entry Templates
+Save common project+category+description combos. One-click to pre-fill log form. Stored in `localStorage`, no schema change needed.
+
+### 5. Weekly Goal Tracking
+Set target hours/week per project. Progress bar on dashboard. Config stored in `localStorage`.
+
+### 6. Export (CSV + PDF)
+CSV already exists via CLI (`tlexport`). Add PDF timesheet export from frontend — grouped by project, date range selectable. Uses browser print API or a lightweight lib.
+
+### 7. Tags
+Free-form labels on entries, filterable. Adds dimension without schema overhaul — stored as comma-separated text column, parsed client-side.
+
+### 8. PWA / Mobile Layout
+Service worker + manifest → installable, works offline for log form. Mobile-friendly layout for field logging.
+
+## Future Vision — Multi-User / Team Edition
+
+> **Not active work.** Long-term vision. Build core personal features first. Everything here is MIT open source — no closed source, no private repos. Single repo, one license.
+
+Goal: same codebase, multi-user support opt-in via config. Default behavior = current single-user local app, unchanged.
+
+### Mode Switch
+`TIMELOG_MODE=single` (default) — no auth, no users table, current behavior exactly.  
+`TIMELOG_MODE=multi` — enables auth middleware, user/org tables, admin routes.  
+One env var. Personal users never notice the enterprise code exists.
+
+### Architecture
+```
+timelog/
+  db.py        ← schema adapts to mode (single vs multi)
+  service.py   ← user_id=1 hardcoded in single mode
+  api.py       ← auth middleware skipped in single mode
+  auth/        ← OIDC middleware, only loaded in multi mode
+  admin/       ← admin routes, only loaded in multi mode
+  billing/     ← invoice engine, only loaded in multi mode
+```
+
+### Auth Strategy (multi mode)
+OIDC via [Dex](https://dexidp.io/) — federates upstream IdPs via connectors:
+- Self-hosted team: Dex sidecar → connector for LDAP/AD/SAML/Google Workspace
+- Direct SSO: point `OIDC_ISSUER` at Google/Okta/Auth0 directly — same code path, no Dex required
+- Local dev: Dex with static passwords connector
+- One env var swap between Dex and any OIDC provider
+
+### Multi-User DB Schema (additive — single mode uses only `entries`)
+```sql
+organizations(id, name, slug, billing_email)
+users(id, org_id, email, oidc_sub, role, name)
+  -- role: admin | manager | member
+  -- no password_hash — OIDC only
+projects(id, org_id, name, client, billing_rate, active)
+categories(id, name)
+entries(id, user_id, project_id, category_id, description, hours, date, approved_by, submitted_at)
+invoices(id, org_id, project_id, period_start, period_end, pdf_path, generated_at)
+```
+
+### New Surface Area (multi mode)
+- **Auth** — OIDC/JWT middleware, Dex or direct SSO
+- **RBAC** — admin / manager / member views
+- **Approval workflow** — submit → manager approves → entry locked
+- **Billing engine** — hours × rate → invoice PDF (`weasyprint` or `reportlab`)
+- **Admin dashboard** — cross-user views, utilization reports
+- **Project budgets** — hour caps, alerts
+- **Client portal** — read-only billed-hours view for clients
+- **Slack/Teams bot** — `/log 2h ProjectX dev` → entry created
+- **Rate cards** — $/hr per user or per project
+
+### What stays shared (all modes)
+- All frontend chart components (heatmap, donuts, bars) — scoped per-user in multi mode
+- Live timer, entry templates
+- Core entry CRUD logic — unchanged
+- CLI — single mode only
+
+### Monetization (future consideration)
+Hosted SaaS: run `timelog.io`, charge $5-8/mo for convenience. Code stays MIT. No enterprise licensing complexity. Decide after the app has real users.
+
 ## Local development (outside Docker)
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 services:
   api:
     build: .
+    restart: unless-stopped
     ports:
       - "8888:8888"
     environment:
@@ -11,6 +12,7 @@ services:
 
   frontend:
     build: ./frontend
+    restart: unless-stopped
     ports:
       - "3000:3000"
     depends_on:

--- a/frontend/src/routes/entries/+page.svelte
+++ b/frontend/src/routes/entries/+page.svelte
@@ -12,6 +12,17 @@
   let dateAsc      = $state(false);
   let selectedDate = $state('');
 
+  const CELL    = 11;
+  const GAP     = 2;
+  const STEP    = CELL + GAP;
+  const LABEL_H = 14;
+  const WEEKS   = 53;
+  const SVG_W   = WEEKS * STEP;
+  const SVG_H   = LABEL_H + 7 * STEP;
+  const FILL_OP = [1, 0.22, 0.45, 0.7, 1];
+
+  let tooltip = $state<{ text: string; x: number; y: number } | null>(null);
+
   function pickDate(date: string) {
     selectedDate = selectedDate === date ? '' : date;
   }
@@ -33,20 +44,67 @@
 
   let filtered = $derived.by(() => {
     const rows = allEntries.filter(e => {
-      if (selectedDate && e.date !== selectedDate)                           return false;
-      if (!selectedDate && dateFilter === 'today'     && e.date !== today)  return false;
+      if (selectedDate && e.date !== selectedDate)                              return false;
+      if (!selectedDate && dateFilter === 'today'     && e.date !== today)     return false;
       if (!selectedDate && dateFilter === 'yesterday' && e.date !== yesterday) return false;
       if (!selectedDate && dateFilter === 'month'     && month && !e.date.startsWith(month)) return false;
-      if (project  && e.project  !== project)                               return false;
-      if (category && e.category !== category)                              return false;
+      if (project  && e.project  !== project)                                  return false;
+      if (category && e.category !== category)                                 return false;
       return true;
     });
-    return dateAsc
-      ? rows
-      : [...rows].reverse();
+    return dateAsc ? rows : [...rows].reverse();
   });
 
   let totalHours = $derived(filtered.reduce((s, e) => s + e.hours, 0));
+
+  let heatmapHours = $derived.by(() => {
+    const m = new Map<string, number>();
+    for (const e of allEntries) {
+      if (project  && e.project  !== project)  continue;
+      if (category && e.category !== category) continue;
+      m.set(e.date, (m.get(e.date) ?? 0) + e.hours);
+    }
+    return m;
+  });
+
+  let gridData = $derived.by(() => {
+    const todayDate = new Date(today + 'T00:00:00');
+    const todayDow  = todayDate.getDay();
+    const startDate = new Date(todayDate);
+    startDate.setDate(startDate.getDate() - 364 - todayDow);
+
+    type Cell = { date: string; hours: number; level: number; inRange: boolean; col: number; row: number };
+    const cells: Cell[] = [];
+
+    for (let i = 0; i < WEEKS * 7; i++) {
+      const d = new Date(startDate);
+      d.setDate(d.getDate() + i);
+      const dateStr = d.toISOString().split('T')[0];
+      const hrs     = heatmapHours.get(dateStr) ?? 0;
+      const level   = hrs === 0 ? 0 : hrs < 2 ? 1 : hrs < 4 ? 2 : hrs < 6 ? 3 : 4;
+      cells.push({
+        date: dateStr, hours: hrs, level,
+        inRange: dateStr <= today,
+        col: Math.floor(i / 7),
+        row: i % 7
+      });
+    }
+
+    const monthLabels: Array<{ col: number; label: string }> = [];
+    let lastMonth = '';
+    for (let col = 0; col < WEEKS; col++) {
+      const mo = cells[col * 7].date.slice(0, 7);
+      if (mo !== lastMonth) {
+        lastMonth = mo;
+        monthLabels.push({
+          col,
+          label: new Date(cells[col * 7].date + 'T12:00:00').toLocaleDateString('en-US', { month: 'short' })
+        });
+      }
+    }
+
+    return { cells, monthLabels };
+  });
 </script>
 
 <div class="page">
@@ -95,6 +153,66 @@
     </div>
   </div>
 
+  {#if !loading && !loadError}
+    <div class="heatmap-section">
+      <svg
+        viewBox="0 0 {SVG_W} {SVG_H}"
+        style="width:100%; max-width:{SVG_W}px; display:block; overflow:visible"
+        aria-label="Activity heatmap — last 12 months"
+        role="img"
+      >
+        {#each gridData.monthLabels as { col, label } (col)}
+          <text
+            x={col * STEP}
+            y={10}
+            style="font-size:9px; fill:var(--text-muted); font-family:inherit"
+          >{label}</text>
+        {/each}
+
+        {#each gridData.cells as cell (cell.date)}
+          <rect
+            x={cell.col * STEP}
+            y={LABEL_H + cell.row * STEP}
+            width={CELL}
+            height={CELL}
+            rx="2"
+            fill={cell.level > 0 && cell.inRange ? 'var(--accent)' : 'var(--surface2)'}
+            fill-opacity={cell.level > 0 && cell.inRange ? FILL_OP[cell.level] : 1}
+            stroke={selectedDate === cell.date ? 'var(--text)' : 'none'}
+            stroke-width="1.5"
+            style="cursor:{cell.inRange ? 'pointer' : 'default'}"
+            onclick={() => { if (cell.inRange) pickDate(cell.date); }}
+            onmouseenter={(e) => {
+              if (!cell.inRange) return;
+              tooltip = {
+                text: cell.hours > 0
+                  ? `${cell.date} — ${cell.hours.toFixed(1)}h`
+                  : `${cell.date} — no activity`,
+                x: e.clientX + 12,
+                y: e.clientY - 36
+              };
+            }}
+            onmouseleave={() => (tooltip = null)}
+          />
+        {/each}
+      </svg>
+
+      <div class="heat-legend">
+        <span class="legend-label">Less</span>
+        {#each [0, 1, 2, 3, 4] as lvl}
+          <svg width={CELL} height={CELL} viewBox="0 0 {CELL} {CELL}" style="display:block">
+            <rect
+              width={CELL} height={CELL} rx="2"
+              fill={lvl > 0 ? 'var(--accent)' : 'var(--surface2)'}
+              fill-opacity={lvl > 0 ? FILL_OP[lvl] : 1}
+            />
+          </svg>
+        {/each}
+        <span class="legend-label">More</span>
+      </div>
+    </div>
+  {/if}
+
   {#if loadError}
     <p class="error">Could not load entries — is <code>tlserve</code> running?</p>
   {:else if loading}
@@ -135,6 +253,10 @@
     </div>
   {/if}
 </div>
+
+{#if tooltip}
+  <div class="hm-tooltip" style="left:{tooltip.x}px;top:{tooltip.y}px">{tooltip.text}</div>
+{/if}
 
 <style>
   .page {
@@ -250,6 +372,41 @@
 
   .calendar-icon:hover { color: var(--accent-light); }
 
+  /* heatmap */
+  .heatmap-section {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .heat-legend {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    justify-content: flex-end;
+  }
+
+  .legend-label {
+    font-size: 0.72rem;
+    color: var(--text-muted);
+    margin: 0 0.15rem;
+  }
+
+  .hm-tooltip {
+    position: fixed;
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    color: var(--text);
+    padding: 0.25rem 0.5rem;
+    border-radius: 5px;
+    font-size: 0.78rem;
+    pointer-events: none;
+    z-index: 1000;
+    white-space: nowrap;
+    font-variant-numeric: tabular-nums;
+  }
+
+  /* table */
   .table-wrap {
     background: var(--surface);
     border: 1px solid var(--border);


### PR DESCRIPTION
## Summary

- 53-week SVG heatmap renders above the entries table, showing hours/day for the last ~12 months
- 5 intensity levels (0h, <2h, <4h, <6h, 6h+) using `--accent` with `fill-opacity` — automatically theme-aware across all 6 themes
- Filter-aware: heatmap intensity reacts to project/category dropdowns but ignores date filters
- Click a cell → sets `selectedDate`, filters table to that day, highlights the cell with a stroke ring
- Month labels above columns, hover tooltip (`YYYY-MM-DD — Xh` or `no activity`), Less/More legend
- Pure inline SVG, no charting library, no new API endpoints — all derived from existing `allEntries` client-side data
- Also adds `restart: unless-stopped` to both docker-compose services

## Test plan

- [x] Navigate to `/entries` — heatmap appears between filters and table
- [x] Verify ~13 month labels render across the top (Apr 2025 → Apr 2026)
- [x] Hover a cell with activity — tooltip shows date and hours
- [x] Hover a cell with no activity — tooltip shows `no activity`
- [x] Hover a future cell (after today) — no tooltip, default cursor
- [x] Click an active cell → `selectedDate` chip appears, table filters to that day, cell gets stroke highlight
- [x] Click the same cell again → deselects, table returns to previous filter state
- [x] Change project dropdown → heatmap intensities update reactively
- [x] Change category dropdown → heatmap intensities update reactively
- [x] Cycle through all 6 themes — heatmap colors follow `--accent` and `--surface2` correctly
- [x] Check legend (`Less ■ ■ ■ ■ ■ More`) renders bottom-right, squares match theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)