### PR TITLE
feat: settings page with file-explorer layout

### DIFF
--- a/frontend/src/lib/SettingsButton.svelte
+++ b/frontend/src/lib/SettingsButton.svelte
@@ -1,0 +1,61 @@
+<script lang="ts">
+  import { page } from '$app/state';
+
+  let onSettings = $derived(page.url.pathname.startsWith('/settings'));
+</script>
+
+<a
+  class="settings-btn"
+  class:active={onSettings}
+  href="/settings"
+  title="Settings"
+  aria-label="Settings"
+>
+  <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+    <circle cx="12" cy="12" r="3" />
+    <path d="M19.4 15a1.7 1.7 0 0 0 .3 1.8l.1.1a2 2 0 1 1-2.8 2.8l-.1-.1a1.7 1.7 0 0 0-1.8-.3 1.7 1.7 0 0 0-1 1.5V21a2 2 0 1 1-4 0v-.1a1.7 1.7 0 0 0-1-1.5 1.7 1.7 0 0 0-1.8.3l-.1.1a2 2 0 1 1-2.8-2.8l.1-.1a1.7 1.7 0 0 0 .3-1.8 1.7 1.7 0 0 0-1.5-1H3a2 2 0 1 1 0-4h.1a1.7 1.7 0 0 0 1.5-1 1.7 1.7 0 0 0-.3-1.8l-.1-.1a2 2 0 1 1 2.8-2.8l.1.1a1.7 1.7 0 0 0 1.8.3h.1a1.7 1.7 0 0 0 1-1.5V3a2 2 0 1 1 4 0v.1a1.7 1.7 0 0 0 1 1.5 1.7 1.7 0 0 0 1.8-.3l.1-.1a2 2 0 1 1 2.8 2.8l-.1.1a1.7 1.7 0 0 0-.3 1.8v.1a1.7 1.7 0 0 0 1.5 1H21a2 2 0 1 1 0 4h-.1a1.7 1.7 0 0 0-1.5 1z" />
+  </svg>
+</a>
+
+<style>
+  .settings-btn {
+    position: fixed;
+    bottom: 1.5rem;
+    left: 1.5rem;
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    background: var(--surface);
+    border: 2px solid var(--border);
+    color: var(--text-muted);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: border-color 0.15s, color 0.15s, transform 0.4s cubic-bezier(0.34, 1.56, 0.64, 1);
+    box-shadow: 0 4px 16px rgba(0, 0, 0, 0.25);
+    z-index: 1000;
+    text-decoration: none;
+  }
+
+  .settings-btn:hover {
+    border-color: var(--accent);
+    color: var(--accent);
+    transform: rotate(45deg);
+  }
+
+  .settings-btn.active {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  .settings-btn svg {
+    width: 22px;
+    height: 22px;
+    fill: none;
+    stroke: currentColor;
+    stroke-width: 1.8;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+  }
+</style>

--- a/frontend/src/lib/TimerWidget.svelte
+++ b/frontend/src/lib/TimerWidget.svelte
@@ -2,6 +2,7 @@
   import { browser } from '$app/environment';
   import { goto } from '$app/navigation';
   import { api } from '$lib/api';
+  import { settings } from '$lib/settings.svelte';
 
   type TimerStatus = 'idle' | 'running';
 
@@ -78,10 +79,16 @@
     timerState = { ...timerState, status: 'running', startedAt: Date.now() };
   }
 
+  function roundHours(rawHours: number, mins: number): number {
+    if (mins === 0) return Math.max(0.01, Math.round(rawHours * 1000) / 1000);
+    const fraction = mins / 60;
+    return Math.max(fraction, Math.round(rawHours / fraction) * fraction);
+  }
+
   function stop() {
     if (!timerState.startedAt) return;
     const rawHours = (Date.now() - timerState.startedAt) / 3600000;
-    const hours = Math.max(0.25, Math.round(rawHours * 4) / 4);
+    const hours = roundHours(rawHours, settings.timerRoundingMinutes);
     if (browser) {
       localStorage.setItem(PREFILL_KEY, JSON.stringify({
         project: timerState.project,

--- a/frontend/src/lib/settings.svelte.ts
+++ b/frontend/src/lib/settings.svelte.ts
@@ -1,0 +1,92 @@
+import { browser } from '$app/environment';
+
+export const THEMES = ['default', 'tokyonight', 'cyberpunk', 'dracula', 'rosepine', 'catppuccin'] as const;
+export type Theme = typeof THEMES[number];
+
+export type WeekStart = 'sun' | 'mon';
+export type RoundingMinutes = 0 | 5 | 15 | 30;
+
+export interface Settings {
+  version: 1;
+  theme: Theme;
+  dailyGoalHours: number;
+  aiSyncEnabled: boolean;
+  weekStart: WeekStart;
+  timerRoundingMinutes: RoundingMinutes;
+  confirmDelete: boolean;
+}
+
+export const DEFAULT_SETTINGS: Settings = {
+  version: 1,
+  theme: 'default',
+  dailyGoalHours: 8,
+  aiSyncEnabled: true,
+  weekStart: 'sun',
+  timerRoundingMinutes: 15,
+  confirmDelete: true,
+};
+
+const STORAGE_KEY = 'timelog-settings';
+const LEGACY_THEME_KEY = 'theme';
+
+function isTheme(v: unknown): v is Theme {
+  return typeof v === 'string' && (THEMES as readonly string[]).includes(v);
+}
+
+function sanitize(raw: unknown): Settings {
+  const out: Settings = { ...DEFAULT_SETTINGS };
+  if (!raw || typeof raw !== 'object') return out;
+  const r = raw as Record<string, unknown>;
+  if (isTheme(r.theme)) out.theme = r.theme;
+  if (typeof r.dailyGoalHours === 'number' && r.dailyGoalHours > 0 && r.dailyGoalHours <= 24) {
+    out.dailyGoalHours = r.dailyGoalHours;
+  }
+  if (typeof r.aiSyncEnabled === 'boolean') out.aiSyncEnabled = r.aiSyncEnabled;
+  if (r.weekStart === 'sun' || r.weekStart === 'mon') out.weekStart = r.weekStart;
+  if (r.timerRoundingMinutes === 0 || r.timerRoundingMinutes === 5 || r.timerRoundingMinutes === 15 || r.timerRoundingMinutes === 30) {
+    out.timerRoundingMinutes = r.timerRoundingMinutes;
+  }
+  if (typeof r.confirmDelete === 'boolean') out.confirmDelete = r.confirmDelete;
+  return out;
+}
+
+function load(): Settings {
+  if (!browser) return { ...DEFAULT_SETTINGS };
+  let parsed: unknown = null;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) parsed = JSON.parse(raw);
+  } catch {}
+  const result = sanitize(parsed);
+
+  // Legacy migration: prior versions stored theme under 'theme'.
+  if (!parsed) {
+    const legacy = localStorage.getItem(LEGACY_THEME_KEY);
+    if (isTheme(legacy)) result.theme = legacy;
+  }
+  if (localStorage.getItem(LEGACY_THEME_KEY) !== null) {
+    localStorage.removeItem(LEGACY_THEME_KEY);
+  }
+  return result;
+}
+
+function save(s: Settings): void {
+  if (!browser) return;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+}
+
+export const settings = $state<Settings>(load());
+
+if (browser) {
+  $effect.root(() => {
+    $effect(() => save({ ...settings }));
+  });
+}
+
+export function setSetting<K extends keyof Settings>(key: K, value: Settings[K]): void {
+  settings[key] = value;
+}
+
+export function resetSettings(): void {
+  Object.assign(settings, DEFAULT_SETTINGS);
+}

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -1,25 +1,14 @@
 <script lang="ts">
   import { browser } from '$app/environment';
   import TimerWidget from '$lib/TimerWidget.svelte';
+  import SettingsButton from '$lib/SettingsButton.svelte';
+  import { settings } from '$lib/settings.svelte';
 
-  const THEMES = ['default', 'tokyonight', 'cyberpunk', 'dracula', 'rosepine', 'catppuccin'] as const;
-  type Theme = typeof THEMES[number];
-
-  function getInitialTheme(): Theme {
-    if (browser) {
-      const saved = localStorage.getItem('theme') as Theme;
-      if (saved && (THEMES as readonly string[]).includes(saved)) return saved;
-    }
-    return 'default';
-  }
-
-  let theme = $state<Theme>(getInitialTheme());
   let { children } = $props();
 
   $effect(() => {
     if (browser) {
-      document.documentElement.setAttribute('data-theme', theme);
-      localStorage.setItem('theme', theme);
+      document.documentElement.setAttribute('data-theme', settings.theme);
     }
   });
 </script>
@@ -36,10 +25,12 @@
         <a href="/">Dashboard</a>
         <a href="/entries">Entries</a>
         <a href="/charts">Charts</a>
-        <a href="/sync">AI Sync</a>
+        {#if settings.aiSyncEnabled}
+          <a href="/sync">AI Sync</a>
+        {/if}
         <a href="/log">Log Time</a>
       </div>
-      <select bind:value={theme} class="theme-select">
+      <select bind:value={settings.theme} class="theme-select">
         <option value="default">Default</option>
         <option value="tokyonight">Tokyo Night</option>
         <option value="cyberpunk">Cyberpunk</option>
@@ -55,6 +46,7 @@
   </main>
 </div>
 
+<SettingsButton />
 <TimerWidget />
 
 <style>

--- a/frontend/src/routes/+page.svelte
+++ b/frontend/src/routes/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { api, type Entry, type ProjectSum } from '$lib/api';
+  import { settings } from '$lib/settings.svelte';
 
   const todayEntries   = api.entries.today();
   const todayHours     = api.sum.today();
@@ -18,10 +19,14 @@
   {:then { hours }}
     <div class="stat-card">
       <span class="stat-label">Hours today</span>
-      <span class="stat-value" class:on-track={hours >= 6} class:low={hours < 4}>
+      <span
+        class="stat-value"
+        class:on-track={hours >= settings.dailyGoalHours * 0.75}
+        class:low={hours < settings.dailyGoalHours * 0.5}
+      >
         {hours.toFixed(2)}
       </span>
-      <span class="stat-sub">of 8.00 goal</span>
+      <span class="stat-sub">of {settings.dailyGoalHours.toFixed(2)} goal</span>
     </div>
   {/await}
 

--- a/frontend/src/routes/charts/+page.svelte
+++ b/frontend/src/routes/charts/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { api, type Entry } from '$lib/api';
+  import { settings } from '$lib/settings.svelte';
 
   let allEntries = $state<Entry[]>([]);
   let loading    = $state(true);
@@ -102,9 +103,9 @@
   const LC_W = 580, LC_H = 140;
   const L_SVG_W = LP_L + LC_W + LP_R;
   const L_SVG_H = LP_T + LC_H + LP_B;
-  const GOAL = 8;
 
   let paceData = $derived.by(() => {
+    const goal = settings.dailyGoalHours;
     const days: { date: string; hours: number }[] = [];
     for (let i = LINE_DAYS - 1; i >= 0; i--) {
       const d = new Date(Date.now() - i * 86400000);
@@ -112,14 +113,14 @@
       const hours = allEntries.filter(e => e.date === date).reduce((s, e) => s + e.hours, 0);
       days.push({ date, hours });
     }
-    const maxH = Math.max(...days.map(d => d.hours), GOAL);
+    const maxH = Math.max(...days.map(d => d.hours), goal);
     const xStep = LC_W / (LINE_DAYS - 1);
     const pts = days.map((d, i) => ({
       ...d,
       x: LP_L + i * xStep,
       y: LP_T + LC_H * (1 - d.hours / maxH)
     }));
-    const goalY = LP_T + LC_H * (1 - GOAL / maxH);
+    const goalY = LP_T + LC_H * (1 - goal / maxH);
     const polyline = pts.map(p => `${p.x},${p.y}`).join(' ');
     const areaD = `M ${pts[0].x} ${LP_T + LC_H} ${pts.map(p => `L ${p.x} ${p.y}`).join(' ')} L ${pts[pts.length - 1].x} ${LP_T + LC_H} Z`;
     const xLabels = [0, 7, 14, 21, 27].map(i => ({ x: LP_L + i * xStep, label: days[i].date.slice(5) }));
@@ -272,7 +273,7 @@
 
     <!-- Pace line -->
     <div class="chart-card">
-      <h2>Daily Pace <span class="sub">last 28 days · dashed = 8h goal</span></h2>
+      <h2>Daily Pace <span class="sub">last 28 days · dashed = {settings.dailyGoalHours}h goal</span></h2>
       <svg viewBox="0 0 {L_SVG_W} {L_SVG_H}" style="width:100%;display:block">
         {#each [0, 0.5, 1] as frac}
           {@const ly = LP_T + LC_H * (1 - frac)}

--- a/frontend/src/routes/entries/+page.svelte
+++ b/frontend/src/routes/entries/+page.svelte
@@ -447,7 +447,7 @@
         <div class="field-row">
           <div class="field">
             <label for="edit-hours">Hours</label>
-            <input id="edit-hours" type="number" step="0.25" min="0.25" bind:value={editHours} />
+            <input id="edit-hours" type="number" step="any" min="0.01" bind:value={editHours} />
           </div>
           <div class="field">
             <label for="edit-date">Date</label>

--- a/frontend/src/routes/entries/+page.svelte
+++ b/frontend/src/routes/entries/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { api, type Entry, type NewEntry } from '$lib/api';
+  import { settings } from '$lib/settings.svelte';
 
   let allEntries  = $state<Entry[]>([]);
   let loading     = $state(true);
@@ -88,10 +89,13 @@
   });
 
   let gridData = $derived.by(() => {
+    const goal      = settings.dailyGoalHours;
     const todayDate = new Date(today + 'T00:00:00');
-    const todayDow  = todayDate.getDay();
+    const todayDow  = todayDate.getDay(); // 0=Sun..6=Sat
+    // When weekStart='mon', shift so Monday is row 0 (offsets are 0=Mon..6=Sun).
+    const dowOffset = settings.weekStart === 'mon' ? (todayDow + 6) % 7 : todayDow;
     const startDate = new Date(todayDate);
-    startDate.setDate(startDate.getDate() - 364 - todayDow);
+    startDate.setDate(startDate.getDate() - 364 - dowOffset);
 
     type Cell = { date: string; hours: number; level: number; inRange: boolean; col: number; row: number };
     const cells: Cell[] = [];
@@ -101,7 +105,12 @@
       d.setDate(d.getDate() + i);
       const dateStr = d.toISOString().split('T')[0];
       const hrs     = heatmapHours.get(dateStr) ?? 0;
-      const level   = hrs === 0 ? 0 : hrs < 2 ? 1 : hrs < 4 ? 2 : hrs < 6 ? 3 : 4;
+      const level   = hrs === 0
+        ? 0
+        : hrs < goal * 0.25 ? 1
+        : hrs < goal * 0.5  ? 2
+        : hrs < goal * 0.75 ? 3
+        : 4;
       cells.push({
         date: dateStr, hours: hrs, level,
         inRange: dateStr <= today,
@@ -196,6 +205,15 @@
       // silent — entry stays in list
     } finally {
       deleting = false;
+    }
+  }
+
+  function startDelete(id: number) {
+    if (settings.confirmDelete) {
+      confirmDelete(id);
+    } else {
+      deleteId = id;
+      doDelete();
     }
   }
 </script>
@@ -363,7 +381,7 @@
                         </div>
                       {:else}
                         <button onclick={(e) => { e.stopPropagation(); openEdit(entry); }}>Edit</button>
-                        <button class="danger" onclick={(e) => { e.stopPropagation(); confirmDelete(entry.id); }}>Delete</button>
+                        <button class="danger" onclick={(e) => { e.stopPropagation(); startDelete(entry.id); }}>Delete</button>
                       {/if}
                     </div>
                   {/if}

--- a/frontend/src/routes/log/+page.svelte
+++ b/frontend/src/routes/log/+page.svelte
@@ -89,7 +89,7 @@
     <div class="row">
       <div class="field">
         <label for="hours">Hours</label>
-        <input id="hours" type="number" step="0.25" min="0.25" bind:value={hours} placeholder="1.5" />
+        <input id="hours" type="number" step="any" min="0.01" bind:value={hours} placeholder="1.5" />
       </div>
       <div class="field">
         <label for="date">Date <span class="optional">(defaults to today)</span></label>

--- a/frontend/src/routes/settings/+layout.svelte
+++ b/frontend/src/routes/settings/+layout.svelte
@@ -1,0 +1,129 @@
+<script lang="ts">
+  import { page } from '$app/state';
+
+  let { children } = $props();
+
+  type Item = { label: string; path: string };
+  type Group = { label: string; items: Item[] };
+
+  // Tree config — designed to grow into multi-mode without UI changes.
+  // When TIMELOG_MODE=multi lands, additional groups (Workspace, Admin) push in here.
+  const groups: Group[] = [
+    {
+      label: 'User',
+      items: [
+        { label: 'General',         path: '/settings/general' },
+        { label: 'Appearance',      path: '/settings/appearance' },
+        { label: 'Timer & Behavior', path: '/settings/timer' },
+        { label: 'AI Sync',         path: '/settings/ai-sync' },
+        { label: 'Data',            path: '/settings/storage' },
+      ],
+    },
+  ];
+
+  let current = $derived(page.url.pathname);
+</script>
+
+<div class="settings-shell">
+  <aside class="tree" aria-label="Settings categories">
+    {#each groups as group (group.label)}
+      <div class="tree-group">
+        <div class="tree-group-label">{group.label}</div>
+        <ul>
+          {#each group.items as item (item.path)}
+            <li>
+              <a
+                href={item.path}
+                class:active={current === item.path}
+              >{item.label}</a>
+            </li>
+          {/each}
+        </ul>
+      </div>
+    {/each}
+  </aside>
+
+  <section class="content">
+    {@render children()}
+  </section>
+</div>
+
+<style>
+  .settings-shell {
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: 1.5rem;
+    min-height: calc(100vh - 56px - 4rem);
+    align-items: start;
+  }
+
+  .tree {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1rem 0.5rem;
+    position: sticky;
+    top: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .tree-group-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--text-muted);
+    padding: 0 0.75rem 0.4rem;
+    font-weight: 600;
+  }
+
+  .tree-group ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+  }
+
+  .tree-group li a {
+    display: block;
+    padding: 0.45rem 0.75rem;
+    border-radius: 6px;
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 0.88rem;
+    transition: background 0.1s, color 0.1s;
+    border-left: 2px solid transparent;
+  }
+
+  .tree-group li a:hover {
+    background: var(--surface2);
+    color: var(--text);
+  }
+
+  .tree-group li a.active {
+    background: var(--surface2);
+    color: var(--accent);
+    border-left-color: var(--accent);
+    font-weight: 500;
+  }
+
+  .content {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 1.75rem 2rem;
+    min-width: 0;
+  }
+
+  @media (max-width: 760px) {
+    .settings-shell {
+      grid-template-columns: 1fr;
+    }
+    .tree {
+      position: static;
+    }
+  }
+</style>

--- a/frontend/src/routes/settings/+page.svelte
+++ b/frontend/src/routes/settings/+page.svelte
@@ -1,0 +1,1 @@
+<!-- Redirect handled in +page.ts. This file exists so SvelteKit treats /settings as a routable parent. -->

--- a/frontend/src/routes/settings/+page.ts
+++ b/frontend/src/routes/settings/+page.ts
@@ -1,0 +1,5 @@
+import { redirect } from '@sveltejs/kit';
+
+export const load = () => {
+  throw redirect(307, '/settings/general');
+};

--- a/frontend/src/routes/settings/ai-sync/+page.svelte
+++ b/frontend/src/routes/settings/ai-sync/+page.svelte
@@ -1,0 +1,137 @@
+<script lang="ts">
+  import { settings } from '$lib/settings.svelte';
+</script>
+
+<h1>AI Sync</h1>
+
+<div class="setting-row">
+  <div class="setting-info">
+    <label for="ai-toggle">Enable AI Sync</label>
+    <p class="hint">
+      AI Sync reads your local Claude Code session history and suggests timelog entries.
+      It is currently a <strong>local-only</strong> feature — the API container needs
+      direct access to <code>~/.claude</code> on this machine. When team mode lands later,
+      this same toggle will become an org-level feature flag.
+    </p>
+  </div>
+  <div class="setting-control">
+    <button
+      id="ai-toggle"
+      class="toggle"
+      class:on={settings.aiSyncEnabled}
+      role="switch"
+      aria-checked={settings.aiSyncEnabled}
+      aria-label="Enable AI Sync"
+      onclick={() => settings.aiSyncEnabled = !settings.aiSyncEnabled}
+      type="button"
+    >
+      <span class="knob"></span>
+    </button>
+  </div>
+</div>
+
+<div class="info-box">
+  <strong>What changes when this is off?</strong>
+  <ul>
+    <li>The "AI Sync" link is hidden from the main navigation.</li>
+    <li>The <code>/sync</code> page shows a placeholder instead of the analyzer.</li>
+    <li>Backend endpoints stay reachable; this is a UI-level toggle only.</li>
+  </ul>
+</div>
+
+<style>
+  h1 {
+    font-size: 1.4rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 1.5rem;
+  }
+
+  .setting-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 2rem;
+    padding: 1.25rem 0;
+    border-bottom: 1px solid var(--border-subtle);
+    align-items: start;
+  }
+
+  .setting-info label {
+    display: block;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 0.3rem;
+  }
+
+  .hint {
+    font-size: 0.83rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+    max-width: 42rem;
+  }
+
+  .toggle {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    width: 44px;
+    height: 24px;
+    cursor: pointer;
+    position: relative;
+    transition: background 0.15s, border-color 0.15s;
+    padding: 0;
+  }
+
+  .toggle.on {
+    background: var(--accent);
+    border-color: var(--accent);
+  }
+
+  .knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--text);
+    transition: transform 0.18s ease, background 0.15s;
+  }
+
+  .toggle.on .knob {
+    transform: translateX(20px);
+    background: #fff;
+  }
+
+  .info-box {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    padding: 0.9rem 1rem;
+    margin-top: 1.25rem;
+    font-size: 0.85rem;
+    color: var(--text-secondary);
+  }
+
+  .info-box strong {
+    color: var(--text);
+    display: block;
+    margin-bottom: 0.4rem;
+  }
+
+  .info-box ul {
+    margin: 0;
+    padding-left: 1.1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  code {
+    background: var(--surface);
+    padding: 0.05em 0.35em;
+    border-radius: 4px;
+    font-size: 0.85em;
+  }
+</style>

--- a/frontend/src/routes/settings/appearance/+page.svelte
+++ b/frontend/src/routes/settings/appearance/+page.svelte
@@ -1,0 +1,164 @@
+<script lang="ts">
+  import { settings, THEMES, type Theme } from '$lib/settings.svelte';
+
+  const labels: Record<Theme, string> = {
+    default: 'Default',
+    tokyonight: 'Tokyo Night',
+    cyberpunk: 'Cyberpunk',
+    dracula: 'Dracula',
+    rosepine: 'Rose Pine',
+    catppuccin: 'Catppuccin Latte',
+  };
+</script>
+
+<h1>Appearance</h1>
+
+<div class="setting-row">
+  <div class="setting-info">
+    <span class="row-label">Theme</span>
+    <p class="hint">
+      Pick a color scheme. The quick-switch dropdown in the top-right corner of every
+      page reflects the same setting.
+    </p>
+  </div>
+</div>
+
+<div class="theme-grid">
+  {#each THEMES as t (t)}
+    <button
+      class="theme-card"
+      class:active={settings.theme === t}
+      data-theme-preview={t}
+      onclick={() => settings.theme = t}
+      type="button"
+    >
+      <div class="swatches">
+        <span class="sw bg"></span>
+        <span class="sw surface"></span>
+        <span class="sw accent"></span>
+        <span class="sw success"></span>
+        <span class="sw warning"></span>
+      </div>
+      <span class="theme-name">{labels[t]}</span>
+      {#if settings.theme === t}
+        <span class="check" aria-hidden="true">✓</span>
+      {/if}
+    </button>
+  {/each}
+</div>
+
+<style>
+  h1 {
+    font-size: 1.4rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 1.5rem;
+  }
+
+  .setting-row {
+    padding-bottom: 1rem;
+  }
+
+  .row-label {
+    display: block;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 0.3rem;
+  }
+
+  .hint {
+    font-size: 0.83rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+    max-width: 42rem;
+  }
+
+  .theme-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+    gap: 0.8rem;
+    margin-top: 0.5rem;
+  }
+
+  .theme-card {
+    background: var(--surface2);
+    border: 2px solid var(--border);
+    border-radius: 10px;
+    padding: 0.85rem;
+    cursor: pointer;
+    text-align: left;
+    transition: border-color 0.15s, transform 0.15s;
+    font-family: inherit;
+    color: var(--text);
+    display: flex;
+    flex-direction: column;
+    gap: 0.55rem;
+    position: relative;
+  }
+
+  .theme-card:hover { border-color: var(--accent-light); }
+  .theme-card.active { border-color: var(--accent); }
+
+  .swatches {
+    display: flex;
+    gap: 0.3rem;
+  }
+
+  .sw {
+    width: 22px;
+    height: 22px;
+    border-radius: 5px;
+    border: 1px solid rgba(0,0,0,0.15);
+  }
+
+  .theme-name {
+    font-size: 0.88rem;
+    font-weight: 500;
+  }
+
+  .check {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.6rem;
+    color: var(--accent);
+    font-weight: 700;
+  }
+
+  /* Per-theme swatch colors. Match the CSS variables defined in +layout.svelte. */
+  [data-theme-preview="default"]    .bg { background: #0f1117; }
+  [data-theme-preview="default"]    .surface { background: #2d3148; }
+  [data-theme-preview="default"]    .accent { background: #6366f1; }
+  [data-theme-preview="default"]    .success { background: #22c55e; }
+  [data-theme-preview="default"]    .warning { background: #f59e0b; }
+
+  [data-theme-preview="tokyonight"] .bg { background: #1a1b26; }
+  [data-theme-preview="tokyonight"] .surface { background: #414868; }
+  [data-theme-preview="tokyonight"] .accent { background: #7aa2f7; }
+  [data-theme-preview="tokyonight"] .success { background: #9ece6a; }
+  [data-theme-preview="tokyonight"] .warning { background: #ff9e64; }
+
+  [data-theme-preview="cyberpunk"]  .bg { background: #0a0a10; }
+  [data-theme-preview="cyberpunk"]  .surface { background: #1e1530; }
+  [data-theme-preview="cyberpunk"]  .accent { background: #ff2d78; }
+  [data-theme-preview="cyberpunk"]  .success { background: #00ffb3; }
+  [data-theme-preview="cyberpunk"]  .warning { background: #ffcc00; }
+
+  [data-theme-preview="dracula"]    .bg { background: #282a36; }
+  [data-theme-preview="dracula"]    .surface { background: #44475a; }
+  [data-theme-preview="dracula"]    .accent { background: #bd93f9; }
+  [data-theme-preview="dracula"]    .success { background: #50fa7b; }
+  [data-theme-preview="dracula"]    .warning { background: #ffb86c; }
+
+  [data-theme-preview="rosepine"]   .bg { background: #191724; }
+  [data-theme-preview="rosepine"]   .surface { background: #26233a; }
+  [data-theme-preview="rosepine"]   .accent { background: #c4a7e7; }
+  [data-theme-preview="rosepine"]   .success { background: #9ccfd8; }
+  [data-theme-preview="rosepine"]   .warning { background: #f6c177; }
+
+  [data-theme-preview="catppuccin"] .bg { background: #eff1f5; }
+  [data-theme-preview="catppuccin"] .surface { background: #ccd0da; }
+  [data-theme-preview="catppuccin"] .accent { background: #8839ef; }
+  [data-theme-preview="catppuccin"] .success { background: #40a02b; }
+  [data-theme-preview="catppuccin"] .warning { background: #df8e1d; }
+</style>

--- a/frontend/src/routes/settings/general/+page.svelte
+++ b/frontend/src/routes/settings/general/+page.svelte
@@ -1,0 +1,127 @@
+<script lang="ts">
+  import { settings, setSetting } from '$lib/settings.svelte';
+
+  let goalInput = $state(String(settings.dailyGoalHours));
+  let goalError = $state('');
+
+  function commitGoal() {
+    const n = parseFloat(goalInput);
+    if (isNaN(n) || n <= 0 || n > 24) {
+      goalError = 'Enter a number between 0.5 and 24.';
+      goalInput = String(settings.dailyGoalHours);
+      return;
+    }
+    goalError = '';
+    setSetting('dailyGoalHours', n);
+  }
+</script>
+
+<h1>General</h1>
+
+<div class="setting-row">
+  <div class="setting-info">
+    <label for="goal">Daily hours goal</label>
+    <p class="hint">
+      Used everywhere the app shows progress toward a daily target — the dashboard stat,
+      the heatmap intensity scale, and the goal line on the charts pace plot.
+    </p>
+  </div>
+  <div class="setting-control">
+    <input
+      id="goal"
+      type="number"
+      step="0.25"
+      min="0.5"
+      max="24"
+      bind:value={goalInput}
+      onblur={commitGoal}
+      onkeydown={(e) => { if (e.key === 'Enter') (e.currentTarget as HTMLInputElement).blur(); }}
+    />
+    <span class="unit">hours</span>
+    {#if goalError}<p class="error">{goalError}</p>{/if}
+  </div>
+</div>
+
+<div class="setting-row">
+  <div class="setting-info">
+    <label for="weekstart">Week starts on</label>
+    <p class="hint">Affects the row alignment of the activity heatmap on the Entries page.</p>
+  </div>
+  <div class="setting-control">
+    <select id="weekstart" bind:value={settings.weekStart}>
+      <option value="sun">Sunday</option>
+      <option value="mon">Monday</option>
+    </select>
+  </div>
+</div>
+
+<style>
+  h1 {
+    font-size: 1.4rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 1.5rem;
+  }
+
+  .setting-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 2rem;
+    padding: 1.25rem 0;
+    border-bottom: 1px solid var(--border-subtle);
+    align-items: start;
+  }
+
+  .setting-row:last-of-type { border-bottom: none; }
+
+  .setting-info label {
+    display: block;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 0.3rem;
+  }
+
+  .hint {
+    font-size: 0.83rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+    max-width: 42rem;
+  }
+
+  .setting-control {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.4rem;
+  }
+
+  .setting-control input,
+  .setting-control select {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    color: var(--text);
+    padding: 0.45rem 0.7rem;
+    font-size: 0.9rem;
+    font-family: inherit;
+    outline: none;
+    min-width: 7rem;
+    transition: border-color 0.15s;
+  }
+
+  .setting-control input:focus,
+  .setting-control select:focus {
+    border-color: var(--accent);
+  }
+
+  .unit {
+    font-size: 0.78rem;
+    color: var(--text-muted);
+  }
+
+  .error {
+    font-size: 0.78rem;
+    color: var(--error);
+  }
+</style>

--- a/frontend/src/routes/settings/storage/+page.svelte
+++ b/frontend/src/routes/settings/storage/+page.svelte
@@ -1,0 +1,115 @@
+<script lang="ts">
+  import { resetSettings } from '$lib/settings.svelte';
+
+  let confirming = $state(false);
+  let resetDone  = $state(false);
+
+  function doReset() {
+    resetSettings();
+    confirming = false;
+    resetDone = true;
+    setTimeout(() => resetDone = false, 2500);
+  }
+</script>
+
+<h1>Data</h1>
+
+<div class="setting-row">
+  <div class="setting-info">
+    <span class="row-label">Reset all settings</span>
+    <p class="hint">
+      Restores every preference on this page back to its default value. Your timelog
+      entries are <strong>not</strong> affected — only this page's settings.
+    </p>
+  </div>
+  <div class="setting-control">
+    {#if resetDone}
+      <span class="ok">Done.</span>
+    {:else if !confirming}
+      <button class="btn-danger" onclick={() => confirming = true} type="button">
+        Reset to defaults
+      </button>
+    {:else}
+      <div class="confirm">
+        <span>Are you sure?</span>
+        <button class="btn-danger" onclick={doReset} type="button">Yes, reset</button>
+        <button class="btn-cancel" onclick={() => confirming = false} type="button">Cancel</button>
+      </div>
+    {/if}
+  </div>
+</div>
+
+<style>
+  h1 {
+    font-size: 1.4rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 1.5rem;
+  }
+
+  .setting-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 2rem;
+    padding: 1.25rem 0;
+    align-items: start;
+  }
+
+  .row-label {
+    display: block;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 0.3rem;
+  }
+
+  .hint {
+    font-size: 0.83rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+    max-width: 42rem;
+  }
+
+  .btn-danger {
+    background: var(--error);
+    color: #fff;
+    border: none;
+    border-radius: 7px;
+    padding: 0.5rem 1rem;
+    font-size: 0.88rem;
+    font-weight: 500;
+    cursor: pointer;
+    font-family: inherit;
+    transition: opacity 0.15s;
+  }
+
+  .btn-danger:hover { opacity: 0.85; }
+
+  .btn-cancel {
+    background: transparent;
+    color: var(--text-muted-mid);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    padding: 0.5rem 1rem;
+    font-size: 0.88rem;
+    cursor: pointer;
+    font-family: inherit;
+    transition: border-color 0.15s;
+  }
+
+  .btn-cancel:hover { border-color: var(--text-muted-mid); }
+
+  .confirm {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.85rem;
+    color: var(--text-muted-mid);
+  }
+
+  .ok {
+    color: var(--success);
+    font-size: 0.88rem;
+    font-weight: 500;
+  }
+</style>

--- a/frontend/src/routes/settings/timer/+page.svelte
+++ b/frontend/src/routes/settings/timer/+page.svelte
@@ -1,0 +1,136 @@
+<script lang="ts">
+  import { settings, type RoundingMinutes } from '$lib/settings.svelte';
+
+  const ROUNDING_OPTIONS: { value: RoundingMinutes; label: string }[] = [
+    { value: 0,  label: 'No rounding (exact)' },
+    { value: 5,  label: '5 minutes' },
+    { value: 15, label: '15 minutes (default)' },
+    { value: 30, label: '30 minutes' },
+  ];
+</script>
+
+<h1>Timer & Behavior</h1>
+
+<div class="setting-row">
+  <div class="setting-info">
+    <label for="rounding">Timer rounding on stop</label>
+    <p class="hint">
+      When you stop the live timer, the elapsed time is rounded to this interval before
+      being pre-filled into the log form. "No rounding" passes the exact decimal hours.
+    </p>
+  </div>
+  <div class="setting-control">
+    <select id="rounding" bind:value={settings.timerRoundingMinutes}>
+      {#each ROUNDING_OPTIONS as opt (opt.value)}
+        <option value={opt.value}>{opt.label}</option>
+      {/each}
+    </select>
+  </div>
+</div>
+
+<div class="setting-row">
+  <div class="setting-info">
+    <label for="confirm-delete">Confirm before deleting an entry</label>
+    <p class="hint">
+      When on, the entries page asks "Delete?" before removing a row. Turn off if you
+      prefer one-click deletion.
+    </p>
+  </div>
+  <div class="setting-control">
+    <button
+      id="confirm-delete"
+      class="toggle"
+      class:on={settings.confirmDelete}
+      role="switch"
+      aria-checked={settings.confirmDelete}
+      aria-label="Confirm before deleting an entry"
+      onclick={() => settings.confirmDelete = !settings.confirmDelete}
+      type="button"
+    >
+      <span class="knob"></span>
+    </button>
+  </div>
+</div>
+
+<style>
+  h1 {
+    font-size: 1.4rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+    margin-bottom: 1.5rem;
+  }
+
+  .setting-row {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 2rem;
+    padding: 1.25rem 0;
+    border-bottom: 1px solid var(--border-subtle);
+    align-items: start;
+  }
+
+  .setting-row:last-of-type { border-bottom: none; }
+
+  .setting-info label {
+    display: block;
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: var(--text);
+    margin-bottom: 0.3rem;
+  }
+
+  .hint {
+    font-size: 0.83rem;
+    color: var(--text-muted);
+    line-height: 1.5;
+    max-width: 42rem;
+  }
+
+  .setting-control select {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 7px;
+    color: var(--text);
+    padding: 0.45rem 0.7rem;
+    font-size: 0.9rem;
+    font-family: inherit;
+    outline: none;
+    min-width: 12rem;
+    transition: border-color 0.15s;
+  }
+
+  .setting-control select:focus { border-color: var(--accent); }
+
+  .toggle {
+    background: var(--surface2);
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    width: 44px;
+    height: 24px;
+    cursor: pointer;
+    position: relative;
+    transition: background 0.15s, border-color 0.15s;
+    padding: 0;
+  }
+
+  .toggle.on {
+    background: var(--accent);
+    border-color: var(--accent);
+  }
+
+  .knob {
+    position: absolute;
+    top: 2px;
+    left: 2px;
+    width: 18px;
+    height: 18px;
+    border-radius: 50%;
+    background: var(--text);
+    transition: transform 0.18s ease, background 0.15s;
+  }
+
+  .toggle.on .knob {
+    transform: translateX(20px);
+    background: #fff;
+  }
+</style>

--- a/frontend/src/routes/sync/+page.svelte
+++ b/frontend/src/routes/sync/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { api, type ProposedEntry } from '$lib/api';
+  import { settings } from '$lib/settings.svelte';
 
   const CATEGORIES = ['Development', 'Debugging', 'Planning', 'Documentation', 'Testing', 'Review'];
 
@@ -92,6 +93,16 @@
     <h1>AI Sync</h1>
     <p class="subtitle">Generate timelog entries from your Claude Code sessions</p>
   </div>
+
+  {#if !settings.aiSyncEnabled}
+    <div class="disabled-state">
+      <p class="disabled-title">AI Sync is disabled.</p>
+      <p class="disabled-hint">
+        Turn it on in <a href="/settings/ai-sync">Settings → AI Sync</a> to analyze
+        your Claude Code session history.
+      </p>
+    </div>
+  {:else}
 
   <div class="controls">
     <input
@@ -234,6 +245,8 @@
     </div>
   {:else if !analyzed && !loading}
     <div class="empty">Pick a date and click <strong>Analyze Sessions</strong> to see your Claude activity.</div>
+  {/if}
+
   {/if}
 </div>
 
@@ -496,5 +509,35 @@
     display: flex;
     justify-content: flex-end;
     margin-top: 1rem;
+  }
+
+  .disabled-state {
+    background: var(--surface);
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    padding: 2rem;
+    text-align: center;
+  }
+
+  .disabled-title {
+    color: var(--text);
+    font-size: 1rem;
+    font-weight: 600;
+    margin: 0 0 0.4rem;
+  }
+
+  .disabled-hint {
+    color: var(--text-muted);
+    font-size: 0.88rem;
+    margin: 0;
+  }
+
+  .disabled-hint a {
+    color: var(--accent);
+    text-decoration: none;
+  }
+
+  .disabled-hint a:hover {
+    text-decoration: underline;
   }
 </style>

--- a/frontend/src/routes/sync/+page.svelte
+++ b/frontend/src/routes/sync/+page.svelte
@@ -202,8 +202,8 @@
                   <input
                     type="number"
                     bind:value={entry.hours}
-                    step="0.25"
-                    min="0.25"
+                    step="any"
+                    min="0.01"
                     max="24"
                     class="hours-input"
                     onblur={() => entry.editingHours = false}


### PR DESCRIPTION
## Summary

- Adds a `/settings` route with a sidebar-tree + content-pane layout, opened from a new gear icon at the bottom-left of every page (mirrors the bottom-right TimerWidget).
- Five categories: **General** (daily hours goal, week start), **Appearance** (theme grid + swatches), **Timer & Behavior** (rounding interval, confirm-before-delete), **AI Sync** (toggle + local-only explainer), **Data** (reset to defaults).
- Centralizes every user preference in a single `$state` store (`lib/settings.svelte.ts`) persisted to one localStorage key. Designed so swapping persistence to a `/api/settings` endpoint when multi-mode lands is a one-file change. Legacy `theme` localStorage key is migrated and removed on first load.
- Wires the daily-hours goal through the dashboard stat, the heatmap intensity scale (thresholds are 25/50/75/100% of goal — `goal=8` preserves existing 2/4/6/8 breakpoints), and the charts pace-plot goal line.
- Top-right theme dropdown still works and is bound to the same store as the Appearance page.
- Toggling AI Sync off hides the nav link and replaces the `/sync` body with a placeholder.

## Future-proofing

The settings tree is config-driven so future modes can add `WORKSPACE` and `ADMIN` groups without touching existing pages. The single-key localStorage layout makes a server-backed swap trivial when team mode arrives.

## Test plan

### Setup
- [x] `tlstart` and visit http://localhost:3000.
- [x] Verify the gear icon appears at the bottom-left and the timer sits at the bottom-right.

### Settings shell
- [x] Click the gear → navigates to `/settings/general` (the bare `/settings` URL also redirects there).
- [x] Sidebar shows a "User" group with: General, Appearance, Timer & Behavior, AI Sync, Data.
- [x] Active item is highlighted; clicking each one swaps the content pane and updates the URL.
- [x] Resizing below ~760px wraps the layout to a single column.

### Daily hours goal
- [x] In **General**, change the goal to `12` and blur the field.
- [x] Dashboard "Hours today" sub-label reads `of 12.00 goal`.
- [x] Dashboard color thresholds shift: green at ≥9h, warning at <6h.
- [x] Charts → Daily Pace heading reads `dashed = 12h goal` and the dashed line moves accordingly.
- [x] Entries heatmap intensity rescales — a day with 7h logged drops a level vs. `goal=8`.
- [x] Restoring `goal=8` returns every visual to the original state (2/4/6/8 thresholds).
- [x] Out-of-range values (e.g. `0`, `30`) are rejected with an inline error and revert.

### Theme parity
- [x] Change theme via the top-right dropdown → the Appearance page reflects the same selection.
- [x] Change theme on the Appearance page → the dropdown updates.
- [x] Refresh — both stay in sync.
- [x] Inspect localStorage: only `timelog-settings`, `timer-state`, `timer-prefill` exist (the legacy `theme` key was migrated and removed).

### Week start
- [x] In **General**, switch to "Monday" → entries page heatmap row alignment shifts so Monday is the top row.

### Timer rounding
- [x] Set **Timer & Behavior → Timer rounding** to "No rounding". Run the timer for ~90 seconds, stop → log form prefills with raw decimal hours (e.g. `0.025`).
- [x] Set rounding to "30 minutes" → same timer rounds to `0.5`.
- [x] Set rounding back to "15 minutes" → matches the previous default behavior (`0.25` minimum).

### Confirm-before-delete
- [x] With the toggle **on**, deleting a row on `/entries` shows the inline "Delete?" prompt before removal.
- [x] With the toggle **off**, "Delete" deletes immediately.

### AI Sync gate
- [x] Toggle **AI Sync → Enable AI Sync** off → the "AI Sync" nav link disappears.
- [x] Visit `/sync` directly → placeholder renders with a link back to settings; the analyzer is not loaded.
- [x] Re-enable → nav link returns and the page works normally.

### Reset
- [x] In **Data**, click "Reset to defaults" → confirm prompt appears → "Yes, reset" reverts every field on every settings page without a page reload (UI updates reactively).
- [x] No timelog entries are affected.

### Type/build sanity
- [x] `cd frontend && npm run check` — 0 errors, no new warnings beyond what existed on `main`.
- [ ] `docker compose up --build -d frontend` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)