### PR TITLE
fix(mobile): contain entries table, wrap nav, pad footer, sweep tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,5 +14,8 @@ build/
 frontend/node_modules/
 frontend/.svelte-kit/
 frontend/build/
+frontend/test-results/
+frontend/playwright-report/
+frontend/static/seed/
 data/
 *.sql

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12,6 +12,7 @@
 				"sql.js": "^1.13.0"
 			},
 			"devDependencies": {
+				"@playwright/test": "^1.59.1",
 				"@sveltejs/adapter-auto": "^7.0.1",
 				"@sveltejs/adapter-node": "^5.5.4",
 				"@sveltejs/adapter-static": "^3.0.10",
@@ -134,6 +135,22 @@
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/Boshen"
+			}
+		},
+		"node_modules/@playwright/test": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+			"integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright": "1.59.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
 			}
 		},
 		"node_modules/@polka/url": {
@@ -1620,6 +1637,53 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/jonschlinkert"
+			}
+		},
+		"node_modules/playwright": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+			"integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"playwright-core": "1.59.1"
+			},
+			"bin": {
+				"playwright": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"optionalDependencies": {
+				"fsevents": "2.3.2"
+			}
+		},
+		"node_modules/playwright-core": {
+			"version": "1.59.1",
+			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+			"integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"bin": {
+				"playwright-core": "cli.js"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
 		},
 		"node_modules/postcss": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,9 +11,13 @@
 		"preview:demo": "VITE_DEMO_MODE=true vite preview",
 		"prepare": "svelte-kit sync || echo ''",
 		"check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
-		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
+		"check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
+		"test:e2e": "playwright test",
+		"test:e2e:ui": "playwright test --ui",
+		"test:e2e:headed": "playwright test --headed"
 	},
 	"devDependencies": {
+		"@playwright/test": "^1.59.1",
 		"@sveltejs/adapter-auto": "^7.0.1",
 		"@sveltejs/adapter-node": "^5.5.4",
 		"@sveltejs/adapter-static": "^3.0.10",

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  globalSetup: './tests/e2e/global-setup.ts',
+  fullyParallel: false,
+  workers: 1,
+  reporter: [['list'], ['html', { open: 'never' }]],
+  use: {
+    baseURL: 'http://localhost:5174',
+    trace: 'on-first-retry',
+  },
+  webServer: {
+    command: 'VITE_DEMO_MODE=true npm run dev -- --port 5174 --strictPort',
+    url: 'http://localhost:5174',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  },
+  projects: [
+    {
+      name: 'razr-portrait',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 412, height: 919 }, hasTouch: true, isMobile: true },
+    },
+    {
+      name: 'iphone-se',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 375, height: 667 }, hasTouch: true, isMobile: true },
+    },
+    {
+      name: 'pixel-7',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 412, height: 915 }, hasTouch: true, isMobile: true },
+    },
+    {
+      name: 'tablet',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 768, height: 1024 } },
+    },
+  ],
+});

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -268,4 +268,27 @@
     margin: 0 auto;
     padding: 2rem;
   }
+
+  @media (max-width: 600px) {
+    header { padding: 0 1rem; }
+
+    nav {
+      height: auto;
+      min-height: 56px;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      padding: 0.5rem 0;
+    }
+
+    .links {
+      gap: 0.85rem;
+      flex-wrap: wrap;
+      order: 3;
+      flex-basis: 100%;
+    }
+
+    .links a { font-size: 0.85rem; }
+
+    main { padding: 1rem; }
+  }
 </style>

--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -289,6 +289,9 @@
 
     .links a { font-size: 0.85rem; }
 
-    main { padding: 1rem; }
+    main {
+      padding: 1rem;
+      padding-bottom: 9rem;
+    }
   }
 </style>

--- a/frontend/src/routes/entries/+page.svelte
+++ b/frontend/src/routes/entries/+page.svelte
@@ -344,7 +344,7 @@
             </th>
             <th>Project</th>
             <th>Category</th>
-            <th>Description</th>
+            <th class="description">Description</th>
             <th>Hours</th>
             <th class="actions-col"></th>
           </tr>
@@ -358,7 +358,7 @@
               <td class="mono date-cell" class:date-active={selectedDate === entry.date} onclick={() => pickDate(entry.date)}>{entry.date}</td>
               <td class="bold project-cell" onclick={() => project = project === entry.project ? '' : entry.project}>{entry.project}</td>
               <td><span class="badge category-cell" onclick={() => category = category === entry.category ? '' : entry.category}>{entry.category}</span></td>
-              <td class="muted">{entry.description || '—'}</td>
+              <td class="muted description">{entry.description || '—'}</td>
               <td class="hours">{entry.hours.toFixed(2)}</td>
               <td class="actions-col">
                 <div class="row-menu">
@@ -619,7 +619,7 @@
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: 10px;
-    overflow: visible;
+    overflow-x: auto;
   }
 
   table {
@@ -943,5 +943,32 @@
     border-radius: 7px;
     font-size: 0.85rem;
     margin-bottom: 0.25rem;
+  }
+
+  @media (max-width: 600px) {
+    th.description,
+    td.description { display: none; }
+
+    thead th,
+    tbody td {
+      padding: 0.55rem 0.4rem;
+      font-size: 0.8rem;
+    }
+
+    tbody td.mono { font-size: 0.78rem; }
+
+    .actions-col { padding: 0 0.25rem 0 0 !important; }
+  }
+
+  @media (max-width: 400px) {
+    thead th,
+    tbody td {
+      padding: 0.5rem 0.3rem;
+      font-size: 0.76rem;
+    }
+
+    tbody td.mono { font-size: 0.74rem; }
+
+    .actions-col { padding: 0 0.15rem 0 0 !important; }
   }
 </style>

--- a/frontend/src/routes/log/+page.svelte
+++ b/frontend/src/routes/log/+page.svelte
@@ -147,6 +147,7 @@
   }
 
   input {
+    box-sizing: border-box;
     background: var(--surface);
     border: 1px solid var(--border);
     border-radius: 8px;
@@ -168,7 +169,7 @@
 
   .row {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
     gap: 1rem;
   }
 

--- a/frontend/tests/e2e/entries-mobile.spec.ts
+++ b/frontend/tests/e2e/entries-mobile.spec.ts
@@ -1,0 +1,42 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('mobile layout — /entries', () => {
+  test('hours column stays inside viewport, no horizontal page overflow, nav fits', async ({ page }, testInfo) => {
+    await page.goto('/entries');
+
+    // Demo mode hydrates sql.js client-side. Wait for either entries or empty-state.
+    await page.waitForLoadState('networkidle');
+    await page.waitForFunction(
+      () => document.querySelector('td.hours') !== null || document.querySelector('.empty') !== null,
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    const vw = testInfo.project.use.viewport!.width;
+
+    // Assertion 1: no horizontal page overflow.
+    const docOverflow = await page.evaluate(() => {
+      const root = document.documentElement;
+      return root.scrollWidth - root.clientWidth;
+    });
+    expect.soft(docOverflow, 'document horizontal overflow').toBeLessThanOrEqual(0);
+
+    // Assertion 2: top nav fits within its container (no horizontal scroll on nav).
+    const navOverflow = await page.evaluate(() => {
+      const nav = document.querySelector('header nav') as HTMLElement | null;
+      if (!nav) return 0;
+      return nav.scrollWidth - nav.clientWidth;
+    });
+    expect.soft(navOverflow, 'nav horizontal overflow').toBeLessThanOrEqual(0);
+
+    // Assertion 3: hours cell — if any rows rendered — sits fully within viewport width.
+    const hasRows = await page.locator('td.hours').count();
+    if (hasRows > 0) {
+      const cell = page.locator('td.hours').first();
+      const box = await cell.boundingBox();
+      expect(box, 'hours cell boundingBox').not.toBeNull();
+      const right = box!.x + box!.width;
+      expect.soft(right, `hours cell right edge (vw=${vw})`).toBeLessThanOrEqual(vw);
+    }
+  });
+});

--- a/frontend/tests/e2e/entries-mobile.spec.ts
+++ b/frontend/tests/e2e/entries-mobile.spec.ts
@@ -39,4 +39,36 @@ test.describe('mobile layout — /entries', () => {
       expect.soft(right, `hours cell right edge (vw=${vw})`).toBeLessThanOrEqual(vw);
     }
   });
+
+  test('footer not occluded by fixed timer or settings widgets', async ({ page }, testInfo) => {
+    test.skip(testInfo.project.name === 'tablet', 'desktop/tablet layout intentionally allows widget overlap');
+
+    await page.goto('/entries');
+    await page.waitForLoadState('networkidle');
+    await page.waitForFunction(
+      () => document.querySelector('.footer') !== null || document.querySelector('.empty') !== null,
+      undefined,
+      { timeout: 15_000 }
+    );
+
+    const footerCount = await page.locator('.footer').count();
+    if (footerCount === 0) test.skip(true, 'no entries → no footer to test');
+
+    // Scroll footer into view at the bottom of the viewport.
+    await page.locator('.footer').scrollIntoViewIfNeeded();
+    await page.evaluate(() => window.scrollTo(0, document.body.scrollHeight));
+    await page.waitForTimeout(200);
+
+    const footer = await page.locator('.footer').boundingBox();
+    const timer = await page.locator('.sprite-btn').boundingBox();
+    const settings = await page.locator('.settings-btn').boundingBox();
+    expect(footer, 'footer boundingBox').not.toBeNull();
+
+    type Box = { x: number; y: number; width: number; height: number };
+    const intersects = (a: Box, b: Box) =>
+      !(a.x + a.width <= b.x || b.x + b.width <= a.x || a.y + a.height <= b.y || b.y + b.height <= a.y);
+
+    if (timer)    expect.soft(intersects(footer!, timer),    'footer overlaps timer widget').toBeFalsy();
+    if (settings) expect.soft(intersects(footer!, settings), 'footer overlaps settings button').toBeFalsy();
+  });
 });

--- a/frontend/tests/e2e/global-setup.ts
+++ b/frontend/tests/e2e/global-setup.ts
@@ -1,0 +1,24 @@
+import { existsSync, mkdirSync, copyFileSync, statSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+export default async function globalSetup() {
+  const src = resolve(__dirname, '../../../data/timelog.db');
+  const dst = resolve(__dirname, '../../static/seed/timelog.db');
+
+  if (!existsSync(src)) {
+    throw new Error(
+      `globalSetup: seed DB not found at ${src}. ` +
+      `Run the main app once (\`tlstart\` + log an entry) so data/timelog.db exists.`
+    );
+  }
+  if (statSync(src).size === 0) {
+    throw new Error(`globalSetup: seed DB at ${src} is empty.`);
+  }
+
+  mkdirSync(dirname(dst), { recursive: true });
+  copyFileSync(src, dst);
+  console.log(`[playwright] copied seed DB → ${dst}`);
+}

--- a/frontend/tests/e2e/mobile-sweep.spec.ts
+++ b/frontend/tests/e2e/mobile-sweep.spec.ts
@@ -1,0 +1,46 @@
+import { expect, test } from '@playwright/test';
+
+const ROUTES = [
+  '/',
+  '/entries',
+  '/charts',
+  '/log',
+  '/sync',
+  '/settings',
+  '/settings/general',
+  '/settings/appearance',
+  '/settings/timer',
+  '/settings/storage',
+  '/settings/ai-sync',
+];
+
+test.describe('mobile sweep — no horizontal overflow', () => {
+  for (const route of ROUTES) {
+    test(`route ${route}`, async ({ page }, info) => {
+      test.skip(info.project.name === 'tablet', 'sweep is mobile-only');
+
+      await page.goto(route);
+      await page.waitForLoadState('networkidle');
+      // small settle for sql.js hydration / client-side fetches
+      await page.waitForTimeout(300);
+
+      const docOverflow = await page.evaluate(() => {
+        const r = document.documentElement;
+        return r.scrollWidth - r.clientWidth;
+      });
+      expect.soft(docOverflow, `${route}: documentElement horizontal overflow`).toBeLessThanOrEqual(0);
+
+      const bodyOverflow = await page.evaluate(() => {
+        const b = document.body;
+        return b.scrollWidth - b.clientWidth;
+      });
+      expect.soft(bodyOverflow, `${route}: body horizontal overflow`).toBeLessThanOrEqual(0);
+
+      const navOverflow = await page.evaluate(() => {
+        const n = document.querySelector('header nav') as HTMLElement | null;
+        return n ? n.scrollWidth - n.clientWidth : 0;
+      });
+      expect.soft(navOverflow, `${route}: nav horizontal overflow`).toBeLessThanOrEqual(0);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Contain entries table on narrow viewports; wrap nav on small screens
- Pad entries footer above fixed timer + settings widgets
- Fix `/log` form input overflow on mobile
- Add Playwright mobile-sweep tests covering all routes for horizontal overflow

## Test plan
- [ ] `cd frontend && npm run test:e2e` passes on razr-portrait, iphone-se, pixel-7, tablet projects
- [ ] Manual check on real mobile viewport: `/`, `/entries`, `/log`, `/settings/*` — no horizontal scroll, footer not occluded