### PR TITLE
fix(api): remove top-level await for iOS Safari < 15 compatibility

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -99,6 +99,55 @@ const realApi = {
   },
 };
 
-export const api: typeof realApi = import.meta.env.VITE_DEMO_MODE
-  ? ((await import('./demo/api')).api as typeof realApi)
-  : realApi;
+// Avoid top-level await so older Safari (iOS < 15) parses this module.
+// In demo mode we resolve the demo api lazily; in main mode we wrap a
+// resolved promise around realApi so the call shape stays uniform. The
+// dynamic import is still gated on VITE_DEMO_MODE so the demo bundle
+// (sql.js + WASM) stays out of the main app chunk.
+const apiPromise: Promise<typeof realApi> = import.meta.env.VITE_DEMO_MODE
+  ? import('./demo/api').then((m) => m.api as typeof realApi)
+  : Promise.resolve(realApi);
+
+function lazy<T extends (...args: any[]) => any>(path: readonly string[]): T {
+  return (async (...args: any[]) => {
+    const root: any = await apiPromise;
+    let target: any = root;
+    let owner: any = root;
+    for (const p of path) {
+      owner = target;
+      target = target[p];
+    }
+    return target.apply(owner, args);
+  }) as T;
+}
+
+export const api: typeof realApi = {
+  entries: {
+    all:        lazy(['entries', 'all']),
+    today:      lazy(['entries', 'today']),
+    yesterday:  lazy(['entries', 'yesterday']),
+    last:       lazy(['entries', 'last']),
+    byMonth:    lazy(['entries', 'byMonth']),
+    byProject:  lazy(['entries', 'byProject']),
+    byCategory: lazy(['entries', 'byCategory']),
+    add:        lazy(['entries', 'add']),
+    update:     lazy(['entries', 'update']),
+    delete:     lazy(['entries', 'delete']),
+  },
+  sum: {
+    all:         lazy(['sum', 'all']),
+    today:       lazy(['sum', 'today']),
+    yesterday:   lazy(['sum', 'yesterday']),
+    byMonth:     lazy(['sum', 'byMonth']),
+    byProject:   lazy(['sum', 'byProject']),
+    byCategory:  lazy(['sum', 'byCategory']),
+    perProject:  lazy(['sum', 'perProject']),
+    perCategory: lazy(['sum', 'perCategory']),
+  },
+  projects:   lazy(['projects']),
+  categories: lazy(['categories']),
+  claude: {
+    preview: lazy(['claude', 'preview']),
+    sync:    lazy(['claude', 'sync']),
+  },
+};


### PR DESCRIPTION
## Summary
- `frontend/src/lib/api.ts` used top-level await to swap real ↔ demo api at module load
- Safari 14 and older treat top-level await as a parse error → entire bundle silently dies → blank page on default theme bg (matches the "blank black page" report from a friend's older iPhone)
- Replaces TLA with a lazy method-by-method delegator backed by a regular Promise; demo bundle separation (sql.js + WASM out of main chunk) is preserved
- Caller signature unchanged — every existing `api.*` call works as-is

## Verification done
- `npm run build` (main): zero .wasm files, zero chunks reference sql.js / initSqlJs / sql-wasm
- `npm run build:demo`: demo functional, sql.js isolated to one chunk
- Headless smoke test: dashboard h1, hours stat, entries count (181) all render

## Test plan
- [ ] On the older iPhone that was previously blank, hit the demo URL → confirm content renders
- [ ] On a modern iPhone (iOS 17+) → confirm no regressions (dashboard, entries, log, charts, theme switch, export PDF, export CSV)
- [ ] Main app stack (`tlstart`) → confirm no behavior change at `localhost:3000`