### PR TITLE
test: cross-browser smoke spec on iPhone + Pixel viewports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,32 @@ invoices(id, org_id, project_id, period_start, period_end, pdf_path, generated_a
 ### Monetization (future consideration)
 Hosted SaaS: run `timelog.io`, charge $5-8/mo for convenience. Code stays MIT. No enterprise licensing complexity. Decide after the app has real users.
 
+## Cross-browser testing
+
+Playwright is configured at `frontend/playwright.config.ts` with multiple project flavors:
+
+- **Mobile-overflow sweep** (Chromium-only): `razr-portrait`, `iphone-se`, `pixel-7`, `tablet` — runs `mobile-sweep.spec.ts` + `entries-mobile.spec.ts` to catch horizontal overflow regressions.
+- **Smoke renders** (Chromium + Firefox at iPhone 13 + Pixel 7): `chromium-iphone-13`, `firefox-iphone-13`, `chromium-pixel-7`, `firefox-pixel-7` — runs `smoke-renders.spec.ts`, asserts every public route renders its h1 within 5s with no console errors. Catches blank-on-load failure modes (the bug class that motivated removing top-level await for iOS Safari < 15).
+- **Demo recording** (`desktop-record`): runs `demo-recording.spec.ts` only, produces the screencast in `frontend/static/demo.webm` via `npm run record:demo`.
+
+Default `npm run test:e2e` runs the mobile sweep + smoke renders across all the above projects. Recording is opt-in via `npm run record:demo`.
+
+### WebKit (Safari engine) — Docker-only on rolling distros
+
+Playwright's WebKit Linux binary links against `libicu.so.74`, which Arch / openSUSE Tumbleweed / other rolling distros do not ship (they have ICU 76+). Two paths:
+
+1. **Run from the official Playwright image (recommended):**
+
+   ```bash
+   docker run --rm --network host -v $PWD:/work -w /work/frontend \
+     mcr.microsoft.com/playwright:v1.59.1-noble \
+     npx playwright test --project=chromium-iphone-13 smoke-renders
+   ```
+
+   Add a `webkit-iphone-13` project to `playwright.config.ts` when running from Docker — the host config omits it because the host can't launch WebKit. The Playwright image bundles WebKit + all required system libs.
+
+2. **Real-device coverage** for old iOS Safari (12, 13, 14) requires BrowserStack / LambdaTest / Sauce Labs — Linux can't run iOS Simulator (Xcode is macOS-only). This is the only way to catch parse-time regressions specific to a particular iOS version.
+
 ## Local development (outside Docker)
 
 ```bash

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -1,5 +1,23 @@
 import { defineConfig, devices } from '@playwright/test';
 
+/**
+ * Cross-browser coverage:
+ *
+ * - Chromium / Firefox at iPhone-13 + Pixel-7 viewports run locally on
+ *   any host (Linux/macOS/Windows) — covers Blink + Gecko engines plus
+ *   touch/mobile viewport regressions on the smoke-renders spec.
+ * - WebKit (Safari engine) is omitted from the local config because
+ *   Playwright's WebKit Linux binary requires libicu.so.74, which Arch
+ *   and other rolling distros do not ship. To run the smoke spec on
+ *   WebKit, use the Playwright Docker image — see CLAUDE.md "Cross-
+ *   browser testing" section.
+ *
+ * Existing mobile-overflow tests stay on the original four mobile/
+ * tablet projects (razr, iphone-se, pixel-7, tablet) using Chromium —
+ * they only assert layout, so engine variety is not needed there.
+ *
+ * The demo-recording spec runs only under desktop-record.
+ */
 export default defineConfig({
   testDir: './tests/e2e',
   globalSetup: './tests/e2e/global-setup.ts',
@@ -19,26 +37,29 @@ export default defineConfig({
     stderr: 'pipe',
   },
   projects: [
+    // ── Mobile-overflow sweep (Chromium-only, layout-focused) ──────
     {
       name: 'razr-portrait',
-      testIgnore: /demo-recording\.spec\.ts/,
+      testIgnore: /demo-recording\.spec\.ts|smoke-renders\.spec\.ts/,
       use: { ...devices['Desktop Chrome'], viewport: { width: 412, height: 919 }, hasTouch: true, isMobile: true },
     },
     {
       name: 'iphone-se',
-      testIgnore: /demo-recording\.spec\.ts/,
+      testIgnore: /demo-recording\.spec\.ts|smoke-renders\.spec\.ts/,
       use: { ...devices['Desktop Chrome'], viewport: { width: 375, height: 667 }, hasTouch: true, isMobile: true },
     },
     {
       name: 'pixel-7',
-      testIgnore: /demo-recording\.spec\.ts/,
+      testIgnore: /demo-recording\.spec\.ts|smoke-renders\.spec\.ts/,
       use: { ...devices['Desktop Chrome'], viewport: { width: 412, height: 915 }, hasTouch: true, isMobile: true },
     },
     {
       name: 'tablet',
-      testIgnore: /demo-recording\.spec\.ts/,
+      testIgnore: /demo-recording\.spec\.ts|smoke-renders\.spec\.ts/,
       use: { ...devices['Desktop Chrome'], viewport: { width: 768, height: 1024 } },
     },
+
+    // ── Demo recording (desktop-only, video on) ─────────────────────
     {
       name: 'desktop-record',
       testMatch: /demo-recording\.spec\.ts/,
@@ -47,6 +68,38 @@ export default defineConfig({
         viewport: { width: 1280, height: 720 },
         video: { mode: 'on', size: { width: 1280, height: 720 } },
         launchOptions: { slowMo: 250 },
+      },
+    },
+
+    // ── Cross-browser smoke (Chromium + Firefox at phone viewports) ─
+    {
+      name: 'chromium-iphone-13',
+      testMatch: /smoke-renders\.spec\.ts/,
+      use: { ...devices['iPhone 13'], browserName: 'chromium' },
+    },
+    {
+      name: 'firefox-iphone-13',
+      testMatch: /smoke-renders\.spec\.ts/,
+      use: {
+        browserName: 'firefox',
+        viewport: { width: 390, height: 844 },
+        userAgent:
+          'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1',
+      },
+    },
+    {
+      name: 'chromium-pixel-7',
+      testMatch: /smoke-renders\.spec\.ts/,
+      use: { ...devices['Pixel 7'] },
+    },
+    {
+      name: 'firefox-pixel-7',
+      testMatch: /smoke-renders\.spec\.ts/,
+      use: {
+        browserName: 'firefox',
+        viewport: { width: 412, height: 915 },
+        userAgent:
+          'Mozilla/5.0 (Android 14; Mobile; rv:128.0) Gecko/128.0 Firefox/128.0',
       },
     },
   ],

--- a/frontend/tests/e2e/smoke-renders.spec.ts
+++ b/frontend/tests/e2e/smoke-renders.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect, type ConsoleMessage, type Page } from '@playwright/test';
+
+/**
+ * Smoke renders — fail-loud test that every public route loads and shows
+ * its h1 within a few seconds, with no console errors. Existed precisely
+ * because a top-level await regression silently rendered the entire app
+ * blank on iOS Safari < 15. A blank-on-load failure mode would not have
+ * been caught by the existing mobile-overflow sweep, so this spec exists
+ * to assert "did anything actually render?" across browsers.
+ */
+
+const ROUTES: { path: string; h1: RegExp }[] = [
+  { path: '/',                    h1: /Timelog|Dashboard/i },
+  { path: '/dashboard',           h1: /Dashboard/i },
+  { path: '/entries',             h1: /Entries/i },
+  { path: '/charts',              h1: /Charts|Analytics/i },
+  { path: '/log',                 h1: /Log Time/i },
+  { path: '/settings',            h1: /Settings|General/i },
+  { path: '/settings/general',    h1: /General/i },
+  { path: '/settings/appearance', h1: /Appearance/i },
+  { path: '/settings/timer',      h1: /Timer/i },
+  { path: '/settings/storage',    h1: /Data/i },
+  { path: '/settings/ai-sync',    h1: /AI Sync/i },
+];
+
+function attachErrorListeners(page: Page): { errors: string[] } {
+  const errors: string[] = [];
+  page.on('console', (msg: ConsoleMessage) => {
+    if (msg.type() === 'error') errors.push(`console.error: ${msg.text()}`);
+  });
+  page.on('pageerror', (err) => {
+    errors.push(`pageerror: ${err.message}`);
+  });
+  return { errors };
+}
+
+test.describe('smoke renders — every route shows its h1, no console errors', () => {
+  for (const { path, h1 } of ROUTES) {
+    test(`route ${path}`, async ({ page }) => {
+      const { errors } = attachErrorListeners(page);
+      await page.goto(path);
+      await page.waitForLoadState('networkidle');
+
+      // Heading must be visible within 5s — proves the bundle parsed,
+      // hydrated, and rendered something (not the blank-on-TLA failure).
+      await expect(page.locator('h1').first()).toBeVisible({ timeout: 5000 });
+      const text = await page.locator('h1').first().textContent();
+      expect.soft(text ?? '', `${path}: h1 text`).toMatch(h1);
+
+      // Allow benign favicon 404 noise; everything else fails the test.
+      const meaningful = errors.filter(e => !/favicon|404/i.test(e));
+      expect.soft(meaningful, `${path}: console errors`).toEqual([]);
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- New \`tests/e2e/smoke-renders.spec.ts\` — every public route renders its h1 within 5s with no console errors
- 4 new Playwright projects: chromium-iphone-13, firefox-iphone-13, chromium-pixel-7, firefox-pixel-7
- Catches the blank-on-load failure mode that the mobile-overflow sweep cannot (overflow assertions can't tell you the app didn't boot)
- 44/44 assertions green on the four configured projects locally

## Why no WebKit project
Playwright's WebKit Linux binary needs libicu.so.74; rolling distros ship 76+. CLAUDE.md gains a "Cross-browser testing" section documenting the Docker path for WebKit coverage and noting real old-iOS Safari requires a paid device cloud (Xcode Simulator is macOS-only).

## Test plan
- [ ] \`cd frontend && npm run test:e2e\` — confirms mobile sweep + smoke renders all pass on the four browser/viewport combos
- [ ] (optional) Run inside Playwright Docker image with WebKit project enabled — see CLAUDE.md "Cross-browser testing" section