### PR TITLE
ci: GitHub Actions workflow + WebKit coverage in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,67 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  frontend:
+    name: frontend (svelte-check + e2e)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install npm deps
+        run: npm ci
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('frontend/package-lock.json') }}
+
+      - name: Install Playwright browsers (chromium + firefox + webkit)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium firefox webkit
+
+      - name: Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps
+
+      - name: Type check (svelte-check)
+        run: npm run check
+        # svelte-check returns nonzero on any error/warning. The repo
+        # has pre-existing a11y warnings on charts/entries/sync that
+        # are unrelated to CI gating, so we surface them but do not
+        # fail the build until they are cleaned up.
+        continue-on-error: true
+
+      - name: e2e (mobile sweep + smoke renders, all browsers + WebKit)
+        run: npm run test:e2e
+        env:
+          CI: 'true'
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: frontend/playwright-report/
+          retention-days: 14

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,21 +217,26 @@ Playwright is configured at `frontend/playwright.config.ts` with multiple projec
 
 Default `npm run test:e2e` runs the mobile sweep + smoke renders across all the above projects. Recording is opt-in via `npm run record:demo`.
 
-### WebKit (Safari engine) — Docker-only on rolling distros
+### WebKit (Safari engine) — CI-only on rolling distros
 
-Playwright's WebKit Linux binary links against `libicu.so.74`, which Arch / openSUSE Tumbleweed / other rolling distros do not ship (they have ICU 76+). Two paths:
+Playwright's WebKit Linux binary links against `libicu.so.74`, which Arch / openSUSE Tumbleweed / other rolling distros do not ship (they have ICU 76+). The repo handles this in two layers:
 
-1. **Run from the official Playwright image (recommended):**
+1. **GitHub Actions CI** (`.github/workflows/ci.yml`) — Ubuntu runner has libicu74 by default, so WebKit projects are added to `playwright.config.ts` automatically when `process.env.CI` is set. Every PR + push to main runs the smoke spec on `webkit-iphone-13` + `webkit-iphone-se` alongside the Chromium/Firefox projects. This gives us real Safari-engine coverage we can't run on the local Arch host.
+2. **Local Docker** (when needed) — run from the official Playwright image:
 
    ```bash
    docker run --rm --network host -v $PWD:/work -w /work/frontend \
      mcr.microsoft.com/playwright:v1.59.1-noble \
-     npx playwright test --project=chromium-iphone-13 smoke-renders
+     bash -c "CI=true npx playwright test --project=webkit-iphone-13 smoke-renders"
    ```
 
-   Add a `webkit-iphone-13` project to `playwright.config.ts` when running from Docker — the host config omits it because the host can't launch WebKit. The Playwright image bundles WebKit + all required system libs.
+3. **Real-device coverage** for old iOS Safari (12, 13, 14) still requires BrowserStack / LambdaTest / Sauce Labs — Linux can't run iOS Simulator (Xcode is macOS-only) and Playwright's WebKit is always recent. This is the only way to catch parse-time regressions specific to a particular iOS version.
 
-2. **Real-device coverage** for old iOS Safari (12, 13, 14) requires BrowserStack / LambdaTest / Sauce Labs — Linux can't run iOS Simulator (Xcode is macOS-only). This is the only way to catch parse-time regressions specific to a particular iOS version.
+## Testing practice
+
+For new behavior, prefer test-first (red → green) where the contract is clear: pure functions, derived values, api shapes, route smoke. Skip TDD for refactors, exploratory UI work, and one-line fixes. The `smoke-renders.spec.ts` exists specifically to catch the kind of silent regression that overflow/layout tests can't surface (e.g. the iOS Safari < 15 top-level await blank-page bug).
+
+When CI fails on a PR, that's the signal to add a test that captures the bug before fixing the bug. Ratchet up coverage; don't drift.
 
 ## Local development (outside Docker)
 

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -6,11 +6,11 @@ import { defineConfig, devices } from '@playwright/test';
  * - Chromium / Firefox at iPhone-13 + Pixel-7 viewports run locally on
  *   any host (Linux/macOS/Windows) — covers Blink + Gecko engines plus
  *   touch/mobile viewport regressions on the smoke-renders spec.
- * - WebKit (Safari engine) is omitted from the local config because
- *   Playwright's WebKit Linux binary requires libicu.so.74, which Arch
- *   and other rolling distros do not ship. To run the smoke spec on
- *   WebKit, use the Playwright Docker image — see CLAUDE.md "Cross-
- *   browser testing" section.
+ * - WebKit (Safari engine) is opt-in via `CI=true` because Playwright's
+ *   WebKit Linux binary requires libicu.so.74, which Arch and other
+ *   rolling distros do not ship. The Ubuntu runner used by GitHub
+ *   Actions has libicu74 out of the box, so CI gets real WebKit
+ *   coverage of the smoke spec on every PR.
  *
  * Existing mobile-overflow tests stay on the original four mobile/
  * tablet projects (razr, iphone-se, pixel-7, tablet) using Chromium —
@@ -18,6 +18,29 @@ import { defineConfig, devices } from '@playwright/test';
  *
  * The demo-recording spec runs only under desktop-record.
  */
+
+const isCI = !!process.env.CI;
+
+const webkitProjects = isCI
+  ? [
+      {
+        name: 'webkit-iphone-13',
+        testMatch: /smoke-renders\.spec\.ts/,
+        use: { ...devices['iPhone 13'] },
+      },
+      {
+        name: 'webkit-iphone-se',
+        testMatch: /smoke-renders\.spec\.ts/,
+        use: {
+          browserName: 'webkit' as const,
+          viewport: { width: 375, height: 667 },
+          userAgent:
+            'Mozilla/5.0 (iPhone; CPU iPhone OS 15_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
+        },
+      },
+    ]
+  : [];
+
 export default defineConfig({
   testDir: './tests/e2e',
   globalSetup: './tests/e2e/global-setup.ts',
@@ -102,5 +125,8 @@ export default defineConfig({
           'Mozilla/5.0 (Android 14; Mobile; rv:128.0) Gecko/128.0 Firefox/128.0',
       },
     },
+
+    // WebKit projects added only in CI (Ubuntu runner has libicu74)
+    ...webkitProjects,
   ],
 });


### PR DESCRIPTION
## Summary
- New \`.github/workflows/ci.yml\` runs on every PR + push to main
- Steps: \`npm ci\`, install Playwright browsers (chromium + firefox + webkit), \`svelte-check\`, \`npm run test:e2e\`
- WebKit projects (webkit-iphone-13, webkit-iphone-se) added to \`playwright.config.ts\` gated on \`process.env.CI\` — Ubuntu CI runner has libicu74, Arch host doesn't
- CLAUDE.md updates: CI replaces the previous Docker-only WebKit guidance + new "Testing practice" section codifies test-first for new behavior

## Why
- Smoke spec (PR #26) only catches regressions if it runs. CI runs it on every PR.
- Local Arch host can't run WebKit; CI Ubuntu can. This is the cleanest path to real Safari-engine coverage.
- \`svelte-check\` is wired up but \`continue-on-error: true\` for now — repo has pre-existing a11y warnings out of scope here.

## Test plan
- [ ] After merge: open a throwaway PR → confirm CI runs and turns green
- [ ] Intentionally break a route (e.g. throw in dashboard layout) → confirm CI fails + uploads playwright-report artifact
- [ ] Look at the WebKit project results — first time we have real Safari-engine coverage on this repo