### PR TITLE
fix(frontend): darken Tokyo Night heatmap empty cell

### DIFF
--- a/frontend/src/routes/+layout.svelte
+++ b/frontend/src/routes/+layout.svelte
@@ -82,6 +82,7 @@
     --accent: #7aa2f7;
     --accent-hover: #3d59a1;
     --accent-light: #a9b1d6;
+    --heatmap-empty: #232742;
     --text: #c0caf5;
     --text-secondary: #a9b1d6;
     --text-muted-mid: #9aa5ce;

--- a/frontend/src/routes/entries/+page.svelte
+++ b/frontend/src/routes/entries/+page.svelte
@@ -381,7 +381,7 @@
             width={CELL}
             height={CELL}
             rx="2"
-            fill={cell.level > 0 && cell.inRange ? 'var(--accent)' : 'var(--surface2)'}
+            fill={cell.level > 0 && cell.inRange ? 'var(--accent)' : 'var(--heatmap-empty, var(--surface2))'}
             fill-opacity={cell.level > 0 && cell.inRange ? FILL_OP[cell.level] : 1}
             stroke={selectedDate === cell.date ? 'var(--text)' : 'none'}
             stroke-width="1.5"
@@ -408,7 +408,7 @@
           <svg width={CELL} height={CELL} viewBox="0 0 {CELL} {CELL}" style="display:block">
             <rect
               width={CELL} height={CELL} rx="2"
-              fill={lvl > 0 ? 'var(--accent)' : 'var(--surface2)'}
+              fill={lvl > 0 ? 'var(--accent)' : 'var(--heatmap-empty, var(--surface2))'}
               fill-opacity={lvl > 0 ? FILL_OP[lvl] : 1}
             />
           </svg>


### PR DESCRIPTION
## Summary
- Tokyo Night's `--surface2` (#414868) was lighter than the level-1 activity cell (`--accent` #7aa2f7 at 0.22 opacity over bg ≈ #2f3954), so empty days appeared brighter than low-activity days on the entries heatmap.
- Introduce a `--heatmap-empty` CSS variable, fallback to `--surface2` for all other themes (unchanged), override to `#232742` for Tokyo Night.
- Legend ramp now reads correctly: empty < lvl1 < lvl2 < lvl3 < lvl4.

## Test plan
- [ ] `tlstart` and switch theme to Tokyo Night on `/entries` — verify empty cells are clearly darker than level-1 cells in both grid and legend.
- [ ] Cycle through Default, Cyberpunk, Dracula, Rose Pine, Catppuccin — confirm heatmap appearance unchanged (fallback to `--surface2`).
- [ ] `npm run test:e2e` — smoke renders pass on all configured projects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)